### PR TITLE
[fix] 비로그인 사용자 login시 로직 수정, Member 엔티티 수정

### DIFF
--- a/src/main/java/com/gachigage/global/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/gachigage/global/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package com.gachigage.global.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import com.gachigage.global.error.CustomException;
+import com.gachigage.global.error.ErrorCode;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final HandlerExceptionResolver resolver;
+
+	public CustomAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+		this.resolver = resolver;
+	}
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) {
+		resolver.resolveException(request, response, null, new CustomException(ErrorCode.UNAUTHORIZED));
+	}
+}

--- a/src/main/java/com/gachigage/global/config/SecurityConfig.java
+++ b/src/main/java/com/gachigage/global/config/SecurityConfig.java
@@ -24,7 +24,8 @@ public class SecurityConfig {
 	private final JwtProvider jwtProvider;
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http,
+		CustomAuthenticationEntryPoint customAuthenticationEntryPoint) throws Exception {
 		http.csrf(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
@@ -38,6 +39,7 @@ public class SecurityConfig {
 				).permitAll()
 				.requestMatchers(HttpMethod.GET, "/products/**").permitAll()
 				.anyRequest().authenticated())
+			.exceptionHandling(handler -> handler.authenticationEntryPoint(customAuthenticationEntryPoint))
 			.oauth2Login(oauth2 -> oauth2
 				.userInfoEndpoint(userInfo -> userInfo
 					.userService(oAuth2UserService))

--- a/src/main/java/com/gachigage/member/Member.java
+++ b/src/main/java/com/gachigage/member/Member.java
@@ -2,6 +2,8 @@ package com.gachigage.member;
 
 import java.time.LocalDate;
 
+import com.gachigage.global.common.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,6 +11,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import lombok.AllArgsConstructor;
@@ -21,7 +24,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Member {
+@Table(name = "member")
+public class Member extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -32,7 +36,7 @@ public class Member {
 	@Column(nullable = false, length = 100, unique = true)
 	private String email;
 
-	@Column(length = 50, unique = true)
+	@Column(length = 50)
 	private String nickname;
 
 	@Column(name = "birth_date")

--- a/src/test/java/com/gachigage/global/error/ApiExceptionHandlerTest.java
+++ b/src/test/java/com/gachigage/global/error/ApiExceptionHandlerTest.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gachigage.global.WithMockCustomUser;
+import com.gachigage.global.config.CustomAuthenticationEntryPoint;
 import com.gachigage.global.config.JwtProvider;
 import com.gachigage.global.config.SecurityConfig;
 import com.gachigage.global.login.service.CustomOAuth2UserService;
@@ -33,12 +34,19 @@ class ApiExceptionHandlerTest {
 
 	@Autowired
 	ObjectMapper objectMapper;
+
 	@MockitoBean
 	private AuthenticationSuccessHandler oAuth2SuccessHandler;
+
 	@MockitoBean
 	private CustomOAuth2UserService oAuth2UserService;
+
+	@MockitoBean
+	private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
 	@MockitoBean
 	private JwtProvider jwtProvider;
+
 	@Autowired
 	private MockMvc mockMvc;
 

--- a/src/test/java/com/gachigage/product/ProductIntegrationTest.java
+++ b/src/test/java/com/gachigage/product/ProductIntegrationTest.java
@@ -207,7 +207,7 @@ public class ProductIntegrationTest {
 		// when & then
 		mockMvc.perform(delete("/products/{productId}", productId))
 			.andDo(print())
-			.andExpect(status().is3xxRedirection());
+			.andExpect(status().isUnauthorized());
 
 	}
 

--- a/src/test/java/com/gachigage/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/gachigage/product/controller/ProductControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gachigage.global.WithMockCustomUser;
+import com.gachigage.global.config.CustomAuthenticationEntryPoint;
 import com.gachigage.global.config.JwtProvider;
 import com.gachigage.global.config.SecurityConfig;
 import com.gachigage.global.login.service.CustomOAuth2UserService;
@@ -61,6 +62,9 @@ class ProductControllerTest {
 
 	@MockitoBean
 	private CustomOAuth2UserService oAuth2UserService;
+
+	@MockitoBean
+	private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
 	private Member member;
 


### PR DESCRIPTION
## 수정한 것
- AuthenticationEntryPoint 구현체 CustomAuthenticationEntryPoint 생성 및 비로그인 사용자 로그인 시 에러 코드 포함한 공통 응답 객체 반환하게 코드 작성
- 관련 테스트 코드 수정
- Member 엔티티 테이블 명 수정 및, 닉네임 unique 해제, baseEntity 상속

## Related
#21 