### PR TITLE
[fix] stomp 관련 로그 작성 및 chat 오타 수정

### DIFF
--- a/src/main/java/com/gachigage/chat/controller/ChatHttpController.java
+++ b/src/main/java/com/gachigage/chat/controller/ChatHttpController.java
@@ -51,7 +51,7 @@ public class ChatHttpController {
 	}
 
 	@Operation(summary = "채팅방 단건 조회", description = "채팅방 ID를 받아 채팅방의 메세지를 Slice 형태로 생성하고 반환합니다.")
-	@GetMapping("/roooms/{chatRoomId}/messages")
+	@GetMapping("/rooms/{chatRoomId}/messages")
 	public ResponseEntity<ApiResponse<Slice<ChatMessageResponseDto>>> getMessages(
 		@Parameter(hidden = true) @AuthenticationPrincipal User user,
 		@PathVariable Long chatRoomId, @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/com/gachigage/chat/domain/ChatMessage.java
+++ b/src/main/java/com/gachigage/chat/domain/ChatMessage.java
@@ -47,7 +47,7 @@ public class ChatMessage {
 	private String content;
 
 	@Enumerated(value = EnumType.STRING)
-	@Column(name = "messsage_type")
+	@Column(name = "message_type")
 	private ChatMessageType messageType;
 
 	@Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/gachigage/global/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/gachigage/global/config/CustomAuthenticationEntryPoint.java
@@ -11,7 +11,9 @@ import com.gachigage.global.error.ErrorCode;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
@@ -24,6 +26,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException authException) {
+		log.warn("EntryPoint: method={} requestURI={} contextPath={} servletPath={}",
+			request.getMethod(),
+			request.getRequestURI(),
+			request.getContextPath(),
+			request.getServletPath()
+		);
 		resolver.resolveException(request, response, null, new CustomException(ErrorCode.UNAUTHORIZED));
 	}
 }

--- a/src/main/java/com/gachigage/global/login/service/OAuth2SuccessHandler.java
+++ b/src/main/java/com/gachigage/global/login/service/OAuth2SuccessHandler.java
@@ -45,7 +45,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		String accessToken = jwtProvider.generateAccessToken(oauthId, claims);
 		log.warn("accessToken: {}", accessToken);
-		String targetUrl = UriComponentsBuilder.fromUriString(frontEndUrl + "/auth/kakao/callback")
+		log.info("frontEndUrl raw = [{}]", frontEndUrl);
+		String targetUrl = UriComponentsBuilder.fromUriString(frontEndUrl.trim() + "/auth/kakao/callback")
 			.queryParam("token", accessToken)
 			.build()
 			.toUriString();


### PR DESCRIPTION
## 구현한 것들
- chat_message 에서 message_type 오타 수정
- 채팅방 단건조회 api 주소 오타 수정
- oauth2handler에서 front url에 trim() 추가